### PR TITLE
处理完请求后，删除保存的flow, 避免内存不断增长

### DIFF
--- a/wyproxy.py
+++ b/wyproxy.py
@@ -47,6 +47,10 @@ class WYProxy(flow.FlowMaster):
                 mysqldb_io = MysqlInterface()            
                 mysqldb_io.insert_result(parser.parser_data())
             f.reply()
+            while 1:
+                if f in self.state.flows:
+                    self.state.delete_flow(f)
+                    break
         return f
 
     # def handle_error(self, f):


### PR DESCRIPTION
RT, 
mitmproxy 会将所有请求保存到一个FlowStore中，在长时间使用后占用的内存会不断增大